### PR TITLE
agrego el parametro admin en getUserData

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,4 +22,4 @@ Pueden correrse tanto tests unitarios como de integracion:
 
 ### Usuarios Administradores
 
-Para validar si un usuario es administrador o no, se usa el endpoint `/getUserData`, el cual devuelve un parámetro booleano `admin`. Para crear usuarios administradores tenemos que ir a la consola de Firebase, Authentication, Users, y obtener el User UID del usuario que queremos convertir en administrador. Luego vamos a Realtime Database, y dentro de la colección `ct-fiuba/rest/admin` crear el documento `<user UID>: true`.
+Para validar si un usuario es administrador o no, se usa el endpoint `/getUserData`, el cual devuelve un parámetro `role` que puede tener el valor "regular" o "admin". Para crear usuarios administradores tenemos que ir a la consola de Firtrueebase, Authentication, Users, y obtener el User UID del usuario que queremos convertir en administrador. Luego vamos a Realtime Database, y dentro de la colección `ct-fiuba/rest/role` crear el documento `<user UID>: admin`.

--- a/README.md
+++ b/README.md
@@ -19,3 +19,7 @@ Pueden correrse tanto tests unitarios como de integracion:
 
     npm run test:unit
     npm run test:integration
+
+### Usuarios Administradores
+
+Para validar si un usuario es administrador o no, se usa el endpoint `/getUserData`, el cual devuelve un parámetro booleano `admin`. Para crear usuarios administradores tenemos que ir a la consola de Firebase, Authentication, Users, y obtener el User UID del usuario que queremos convertir en administrador. Luego vamos a Realtime Database, y dentro de la colección `ct-fiuba/rest/admin` crear el documento `<user UID>: true`.

--- a/src/gateways/firebaseGateway.js
+++ b/src/gateways/firebaseGateway.js
@@ -48,6 +48,18 @@ module.exports = function firebaseGateway(firebaseAuth) {
       });
   }
 
+  const isAdminUser = (userId) => {
+    return firebaseDatabaseAPI.get(`admin.json?orderBy="$key"&equalTo="${userId}"`)
+      .then(firebaseDatabaseResponse => {
+        return JSON.parse(firebaseDatabaseResponse.body);
+      })
+      .catch(error => {
+        const status = error.response.statusCode;
+        const message = JSON.parse(error.response.body).error.message;
+        throw new RequestError(message, status);
+      });
+  }
+
   const signUp = async userInfo => {
     const { idToken, email, refreshToken, expiresIn, localId } = await requestAuthFirebase('signUp', { ...userInfo, returnSecureToken: true });
     await putUserDNI(localId, userInfo.DNI);
@@ -116,6 +128,7 @@ module.exports = function firebaseGateway(firebaseAuth) {
   const getUserData = async idToken => {
     const { users } = await requestAuthFirebase('lookup', { idToken });
     dni_response = await getUserDNI(users[0]['localId']);
+    admin_response = await isAdminUser(users[0]['localId']);
     return {
       "userId": users[0]['localId'],
       "email": users[0]['email'],
@@ -124,7 +137,8 @@ module.exports = function firebaseGateway(firebaseAuth) {
       "photoUrl": users[0]['photoUrl'],
       "lastLoginAt": users[0]['lastLoginAt'],
       "createdAt": users[0]['createdAt'],
-      "DNI": dni_response[users[0]['localId']]['DNI']
+      "DNI": dni_response.hasOwnProperty(users[0]['localId']) ? dni_response[users[0]['localId']]['DNI'] : "Sin documento registrado",
+      "admin": admin_response.hasOwnProperty(users[0]['localId']) ? true : false
     };
   };
 

--- a/src/gateways/firebaseGateway.js
+++ b/src/gateways/firebaseGateway.js
@@ -48,8 +48,8 @@ module.exports = function firebaseGateway(firebaseAuth) {
       });
   }
 
-  const isAdminUser = (userId) => {
-    return firebaseDatabaseAPI.get(`admin.json?orderBy="$key"&equalTo="${userId}"`)
+  const getUserRole = (userId) => {
+    return firebaseDatabaseAPI.get(`role.json?orderBy="$key"&equalTo="${userId}"`)
       .then(firebaseDatabaseResponse => {
         return JSON.parse(firebaseDatabaseResponse.body);
       })
@@ -128,7 +128,7 @@ module.exports = function firebaseGateway(firebaseAuth) {
   const getUserData = async idToken => {
     const { users } = await requestAuthFirebase('lookup', { idToken });
     dni_response = await getUserDNI(users[0]['localId']);
-    admin_response = await isAdminUser(users[0]['localId']);
+    role_response = await getUserRole(users[0]['localId']);
     return {
       "userId": users[0]['localId'],
       "email": users[0]['email'],
@@ -138,7 +138,7 @@ module.exports = function firebaseGateway(firebaseAuth) {
       "lastLoginAt": users[0]['lastLoginAt'],
       "createdAt": users[0]['createdAt'],
       "DNI": dni_response.hasOwnProperty(users[0]['localId']) ? dni_response[users[0]['localId']]['DNI'] : "Sin documento registrado",
-      "admin": admin_response.hasOwnProperty(users[0]['localId']) ? admin_response[users[0]['localId']] : false
+      "role": role_response.hasOwnProperty(users[0]['localId']) ? role_response[users[0]['localId']] : "regular"
     };
   };
 

--- a/src/gateways/firebaseGateway.js
+++ b/src/gateways/firebaseGateway.js
@@ -138,7 +138,7 @@ module.exports = function firebaseGateway(firebaseAuth) {
       "lastLoginAt": users[0]['lastLoginAt'],
       "createdAt": users[0]['createdAt'],
       "DNI": dni_response.hasOwnProperty(users[0]['localId']) ? dni_response[users[0]['localId']]['DNI'] : "Sin documento registrado",
-      "admin": admin_response.hasOwnProperty(users[0]['localId']) ? true : false
+      "admin": admin_response.hasOwnProperty(users[0]['localId']) ? admin_response[users[0]['localId']] : false
     };
   };
 

--- a/src/static/swagger.json
+++ b/src/static/swagger.json
@@ -804,9 +804,9 @@
             "type": "string",
             "example": "40404040"
           },
-          "admin": {
-            "type": "boolean",
-            "example": true
+          "role": {
+            "type": "string",
+            "example": "regular"
           }
         }
       }

--- a/src/static/swagger.json
+++ b/src/static/swagger.json
@@ -803,6 +803,10 @@
           "DNI": {
             "type": "string",
             "example": "40404040"
+          },
+          "admin": {
+            "type": "boolean",
+            "example": true
           }
         }
       }

--- a/test/integration/app.int.test.js
+++ b/test/integration/app.int.test.js
@@ -423,7 +423,7 @@ describe('App test', () => {
     let firebase_db_dni_response = {}
     firebase_db_dni_response[localId_get_user] = {DNI: dni};
     let firebase_db_admin_response = {}
-    firebase_db_admin_response[localId_get_user] = true;
+    firebase_db_admin_response[localId_get_user] = false;
 
     describe('getUserData', () => {
       beforeEach(() => {

--- a/test/integration/app.int.test.js
+++ b/test/integration/app.int.test.js
@@ -417,13 +417,11 @@ describe('App test', () => {
       "lastLoginAt": "1484628946000",
       "createdAt": "1484124142000",
       "DNI": dni,
-      "admin": false,
+      "role": "regular",
     };
 
     let firebase_db_dni_response = {}
     firebase_db_dni_response[localId_get_user] = {DNI: dni};
-    let firebase_db_admin_response = {}
-    firebase_db_admin_response[localId_get_user] = false;
 
     describe('getUserData', () => {
       beforeEach(() => {
@@ -436,8 +434,8 @@ describe('App test', () => {
           .reply(200, firebase_db_dni_response);
 
         nock('https://ct-fiuba.firebaseio.com/rest')
-          .get(`/admin.json?orderBy=%22$key%22&equalTo="${localId_get_user}"`)
-          .reply(200, firebase_db_admin_response);
+          .get(`/role.json?orderBy=%22$key%22&equalTo="${localId_get_user}"`)
+          .reply(200, {});
       });
 
       test('should return 200 when retrieving user data', async () => {

--- a/test/integration/app.int.test.js
+++ b/test/integration/app.int.test.js
@@ -416,11 +416,14 @@ describe('App test', () => {
       "photoUrl": "https://lh5.googleusercontent.com/.../photo.jpg",
       "lastLoginAt": "1484628946000",
       "createdAt": "1484124142000",
-      "DNI": dni
+      "DNI": dni,
+      "admin": false,
     };
 
-    let firebase_db_response = {}
-    firebase_db_response[localId_get_user] = {DNI: dni};
+    let firebase_db_dni_response = {}
+    firebase_db_dni_response[localId_get_user] = {DNI: dni};
+    let firebase_db_admin_response = {}
+    firebase_db_admin_response[localId_get_user] = true;
 
     describe('getUserData', () => {
       beforeEach(() => {
@@ -430,7 +433,11 @@ describe('App test', () => {
 
         nock('https://ct-fiuba.firebaseio.com/rest')
           .get(`/users.json?orderBy=%22$key%22&equalTo="${localId_get_user}"`)
-          .reply(200, firebase_db_response);
+          .reply(200, firebase_db_dni_response);
+
+        nock('https://ct-fiuba.firebaseio.com/rest')
+          .get(`/admin.json?orderBy=%22$key%22&equalTo="${localId_get_user}"`)
+          .reply(200, firebase_db_admin_response);
       });
 
       test('should return 200 when retrieving user data', async () => {


### PR DESCRIPTION
Agrego un parámetro role que muestra qué rol tiene el usuario. Si no tiene ningun rol asignado a mano en firebase es un usuario regular.

Para crear un usuario admin vamos a la consola de firebase de Auth, y seleccionamos el User UID del usuario que queremos convertir en admin.
![image](https://user-images.githubusercontent.com/22566107/107890621-ab4fa380-6ef8-11eb-91dd-3b6ba9cd5970.png)

Después vamos a Realtime Database y creamos un nuevo documento en la sección `ct-fiuba/rest/role` con el formato `<User UID>: "admin"`:
![image](https://user-images.githubusercontent.com/22566107/107986541-1063d180-6fab-11eb-96a7-7a03d307d573.png)
![image](https://user-images.githubusercontent.com/22566107/107986584-240f3800-6fab-11eb-9eee-4271284c2888.png)
![image](https://user-images.githubusercontent.com/22566107/107986603-2a9daf80-6fab-11eb-8003-9b2d66224198.png)




Después para ver si un usuario logueado es admin tenemos que:
1. Loguearnos con ese usuario: 
![image](https://user-images.githubusercontent.com/22566107/107890711-1600df00-6ef9-11eb-9a6d-78dbf15917ba.png)
2. Agarramos el access token devuelto y le pegamos a `/getUserData` y vemos que role es admin: 
![image](https://user-images.githubusercontent.com/22566107/107986677-57ea5d80-6fab-11eb-9df3-903f5b5580c2.png)


El rol de un usuario normal es "regular":
![image](https://user-images.githubusercontent.com/22566107/107986772-8405de80-6fab-11eb-9b7f-57e429cef3a5.png)


